### PR TITLE
dont transcode audio

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -44,8 +44,7 @@ fn main() {
             "-preset", "ultrafast",
             "-tune", "stillimage",
             "-framerate", "1",
-            "-c:a", "aac",
-            "-b:a", "320k",
+            "-c:a", "copy",
             "-shortest",
             "-y",
             format!("{}/output.mp4", fadein_parent).as_str()


### PR DESCRIPTION
youtube doesn't care about the audio format in an mp4 container and just transcodes it itself again, doing it here just makes the audio quality a little worse for no real reason